### PR TITLE
Bump luau-lsp to fix CI analysis

### DIFF
--- a/foreman.toml
+++ b/foreman.toml
@@ -1,5 +1,5 @@
 [tools]
-luau-lsp = { source = "JohnnyMorganz/luau-lsp", version = "=1.52.0" }
+luau-lsp = { source = "JohnnyMorganz/luau-lsp", version = "=1.53.0" }
 lune = { source = "lune-org/lune", version = "=0.9.4" }
 rojo = { source = "rojo-rbx/rojo", version = "=7.5.0" }
 selene = { source = "kampfkarren/selene", version = "=0.28.0" }


### PR DESCRIPTION
Foreman has an outstanding bug that was preventing us from downloading the correct luau-lsp in CI. luau-lsp was updated to publish compatible binaries, so while the Foreman issue still exists we're no longer blocked on running Luau analysis

See this issue for more details https://github.com/JohnnyMorganz/luau-lsp/issues/1151