### PR TITLE
MUS-2479 Add end-to-end tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install dependencies
         run: lune run install
 
-      - name: Run unit tests
+      - name: Run end-to-end tests
         run: lune run test-e2e
         env:
           ROBLOX_API_KEY: ${{ secrets.ROBLOX_API_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
 
       - name: Run unit tests
         run: lune run test
+        env:
+          ROBLOX_API_KEY: ${{ secrets.ROBLOX_API_KEY }}
 
   code-quality:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,23 @@ jobs:
 
       - name: Run unit tests
         run: lune run test
+
+  test-e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: Roblox/setup-foreman@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          allow-external-github-orgs: true
+
+      - name: Install dependencies
+        run: lune run install
+
+      - name: Run unit tests
+        run: lune run test-e2e
         env:
           ROBLOX_API_KEY: ${{ secrets.ROBLOX_API_KEY }}
 

--- a/.luaurc
+++ b/.luaurc
@@ -2,6 +2,7 @@
   "languageMode": "strict",
   "aliases": {
     "root": "src",
+    "examples": "examples",
     "pkg": "pkg",
     "lune": "~/.lune/.typedefs/0.9.3"
   }

--- a/.lune/test-e2e.luau
+++ b/.lune/test-e2e.luau
@@ -20,7 +20,7 @@ local function loadTestCases(path: string, alias: string)
 	end
 end
 
-loadTestCases("src", "@root")
+loadTestCases("examples", "@examples")
 
 reporter.init()
 local success = frktest.run()

--- a/.lune/test.luau
+++ b/.lune/test.luau
@@ -20,10 +20,7 @@ local function loadTestCases(path: string, alias: string)
 	end
 end
 
-print("Unit tests:")
 loadTestCases("src", "@root")
-
-print("Integration tests:")
 loadTestCases("examples", "@examples")
 
 reporter.init()

--- a/.lune/test.luau
+++ b/.lune/test.luau
@@ -7,9 +7,9 @@ local run = require("@root/lib/run")
 
 local reporter = frktest._reporters.lune_console_reporter
 
-local function loadTestCases()
-	local output = run("find", { "src", "-iname", "*.spec.luau" })
-	output = output:gsub("src/", "@root/")
+local function loadTestCases(path: string, alias: string)
+	local output = run("find", { path, "-iname", "*.spec.luau" })
+	output = output:gsub(path, alias)
 
 	local files = output:split("\n")
 
@@ -20,7 +20,11 @@ local function loadTestCases()
 	end
 end
 
-loadTestCases()
+print("Unit tests:")
+loadTestCases("src", "@root")
+
+print("Integration tests:")
+loadTestCases("examples", "@examples")
 
 reporter.init()
 local success = frktest.run()

--- a/examples/package/e2e.spec.luau
+++ b/examples/package/e2e.spec.luau
@@ -63,11 +63,9 @@ test.case("text fields in rbxasest.toml get mirrored to the asset details", func
 
 	assetDetails = getAssetDetailsAsync(assetId, apiKey)
 
-	-- Revision ID should be the same since we aren't changing the source code
-	check.equal(assetDetails.revisionId, prevRevisionId)
-
 	check.equal(assetDetails.displayName, manifest.assets.package.name)
 	check.equal(assetDetails.description, manifest.assets.package.description)
+	check.not_equal(assetDetails.revisionId, prevRevisionId)
 end)
 
 test.case("does not publish a new version when there are no changes", function()

--- a/examples/package/e2e.spec.luau
+++ b/examples/package/e2e.spec.luau
@@ -81,7 +81,3 @@ test.case("does not publish a new version when there are no changes", function()
 
 	check.equal(assetDetails.revisionId, prevRevisionId)
 end)
-
--- Use rbxcloud or build out some Open Cloud luau scripts to handle all the
--- validation. It would likely be fastest to use rbxcloud, but more
--- beneficial longterm to write everything in Luau

--- a/examples/package/e2e.spec.luau
+++ b/examples/package/e2e.spec.luau
@@ -13,6 +13,12 @@ local check = frktest.assert.check
 local ROOT_PATH = "examples/package"
 local MANIFEST_PATH = `{ROOT_PATH}/rbxasset.toml`
 
+local function appendTextForTesting(path: string, text: string)
+	local content = fs.readFile(path)
+	content ..= text
+	fs.writeFile(path, content)
+end
+
 local apiKey = process.env.ROBLOX_API_KEY
 assert(apiKey, "End-to-end tests can only be run when the ROBLOX_API_KEY envvar is set to a valid Open Cloud API key")
 
@@ -28,9 +34,7 @@ test.case("uploads rbxm to the Creator Store", function()
 	local prevRevisionId = assetDetails.revisionId
 
 	local path = `{ROOT_PATH}/src/init.luau`
-	local content = fs.readFile(path)
-	content ..= `\nprint("New!")`
-	fs.writeFile(path, content)
+	appendTextForTesting(path, `\nprint("New!")`)
 
 	process.exec("lune", { "run", "deploy.luau", apiKey }, {
 		cwd = ROOT_PATH,

--- a/examples/package/e2e.spec.luau
+++ b/examples/package/e2e.spec.luau
@@ -53,7 +53,7 @@ test.case("text fields in rbxasest.toml get mirrored to the asset details", func
 
 	local manifest = readManifest(ROOT_PATH)
 
-	local id = math.random(1, 1e10)
+	local id = os.time()
 	manifest.assets.package.name = `{manifest.assets.package.name}\n({id})`
 	manifest.assets.package.description = `{manifest.assets.package.description}\n({id})`
 

--- a/examples/package/e2e.spec.luau
+++ b/examples/package/e2e.spec.luau
@@ -1,0 +1,65 @@
+local frktest = require("@pkg/frktest")
+local fs = require("@lune/fs")
+local process = require("@lune/process")
+
+local getAssetDetailsAsync = require("@root/requests/getAssetDetailsAsync")
+local getOrCreateAssetLockfile = require("@root/manifest/getOrCreateAssetLockfile")
+
+local test = frktest.test
+local check = frktest.assert.check
+
+local ROOT_PATH = "examples/package"
+
+local apiKey = process.env.ROBLOX_API_KEY
+assert(apiKey, "End-to-end tests can only be run when the ROBLOX_API_KEY envvar is set to a valid Open Cloud API key")
+
+local lockfile = getOrCreateAssetLockfile(ROOT_PATH)
+local assetId = lockfile.assets.package.assetId
+
+process.exec("rojo", { "build", "-o", "asset.rbxm" }, {
+	cwd = ROOT_PATH,
+})
+
+test.case("uploads to the Creator Store", function()
+	local assetDetails = getAssetDetailsAsync(assetId, apiKey)
+
+	local prevRevisionId = assetDetails.revisionId
+
+	print("assetDetails", assetDetails)
+
+	local path = `{ROOT_PATH}/src/init.luau`
+	local content = fs.readFile(path)
+	content ..= `\nprint("New!")`
+	fs.writeFile(path, content)
+
+	process.exec("lune", { "run", "deploy.luau", apiKey }, {
+		cwd = ROOT_PATH,
+	})
+
+	-- TODO: This should be run after each test
+	process.exec("git", { "restore", ROOT_PATH })
+
+	assetDetails = getAssetDetailsAsync(assetId, apiKey)
+
+	print("assetDetails", assetDetails)
+
+	check.not_equal(assetDetails.revisionId, prevRevisionId)
+end)
+
+test.case("does not publish a new version when there are no changes", function()
+	local assetDetails = getAssetDetailsAsync(assetId, apiKey)
+
+	local prevRevisionId = assetDetails.revisionId
+
+	process.exec("lune", { "run", "deploy.luau", apiKey }, {
+		cwd = ROOT_PATH,
+	})
+
+	assetDetails = getAssetDetailsAsync(assetId, apiKey)
+
+	check.equal(assetDetails.revisionId, prevRevisionId)
+end)
+
+-- Use rbxcloud or build out some Open Cloud luau scripts to handle all the
+-- validation. It would likely be fastest to use rbxcloud, but more
+-- beneficial longterm to write everything in Luau

--- a/examples/package/e2e.spec.luau
+++ b/examples/package/e2e.spec.luau
@@ -1,14 +1,17 @@
 local frktest = require("@pkg/frktest")
 local fs = require("@lune/fs")
 local process = require("@lune/process")
+local serde = require("@lune/serde")
 
 local getAssetDetailsAsync = require("@root/requests/getAssetDetailsAsync")
 local getOrCreateAssetLockfile = require("@root/manifest/getOrCreateAssetLockfile")
+local readManifest = require("@root/manifest/readManifest")
 
 local test = frktest.test
 local check = frktest.assert.check
 
 local ROOT_PATH = "examples/package"
+local MANIFEST_PATH = `{ROOT_PATH}/rbxasset.toml`
 
 local apiKey = process.env.ROBLOX_API_KEY
 assert(apiKey, "End-to-end tests can only be run when the ROBLOX_API_KEY envvar is set to a valid Open Cloud API key")
@@ -20,12 +23,9 @@ process.exec("rojo", { "build", "-o", "asset.rbxm" }, {
 	cwd = ROOT_PATH,
 })
 
-test.case("uploads to the Creator Store", function()
+test.case("uploads rbxm to the Creator Store", function()
 	local assetDetails = getAssetDetailsAsync(assetId, apiKey)
-
 	local prevRevisionId = assetDetails.revisionId
-
-	print("assetDetails", assetDetails)
 
 	local path = `{ROOT_PATH}/src/init.luau`
 	local content = fs.readFile(path)
@@ -36,14 +36,38 @@ test.case("uploads to the Creator Store", function()
 		cwd = ROOT_PATH,
 	})
 
-	-- TODO: This should be run after each test
-	process.exec("git", { "restore", ROOT_PATH })
+	process.exec("git", { "restore", path })
 
 	assetDetails = getAssetDetailsAsync(assetId, apiKey)
 
-	print("assetDetails", assetDetails)
-
 	check.not_equal(assetDetails.revisionId, prevRevisionId)
+end)
+
+test.case("text fields in rbxasest.toml get mirrored to the asset details", function()
+	local assetDetails = getAssetDetailsAsync(assetId, apiKey)
+	local prevRevisionId = assetDetails.revisionId
+
+	local manifest = readManifest(ROOT_PATH)
+
+	local id = math.random(1, 1e10)
+	manifest.assets.package.name = `{manifest.assets.package.name}\n({id})`
+	manifest.assets.package.description = `{manifest.assets.package.description}\n({id})`
+
+	fs.writeFile(MANIFEST_PATH, serde.encode("toml", manifest))
+
+	process.exec("lune", { "run", "deploy.luau", apiKey }, {
+		cwd = ROOT_PATH,
+	})
+
+	process.exec("git", { "restore", MANIFEST_PATH })
+
+	assetDetails = getAssetDetailsAsync(assetId, apiKey)
+
+	-- Revision ID should be the same since we aren't changing the source code
+	check.equal(assetDetails.revisionId, prevRevisionId)
+
+	check.equal(assetDetails.displayName, manifest.assets.package.name)
+	check.equal(assetDetails.description, manifest.assets.package.description)
 end)
 
 test.case("does not publish a new version when there are no changes", function()

--- a/examples/package/rbxasset.lock
+++ b/examples/package/rbxasset.lock
@@ -1,6 +1,6 @@
 [assets.package]
-assetId = "120786139379662"
+assetId = "85269576874155"
 
 [images."icon.png"]
-assetId = "95124518202499"
+assetId = "108457732972751"
 hash = "fac185770cf5e824d4c0a9b59e547df42dc10011c5ad139bfc2c7e1507eef631"

--- a/examples/package/src/init.luau
+++ b/examples/package/src/init.luau
@@ -1,0 +1,1 @@
+print("This is a Package!")

--- a/examples/package/src/init.plugin.luau
+++ b/examples/package/src/init.plugin.luau
@@ -1,1 +1,0 @@
-print("This is a plugin!")

--- a/examples/plugin/e2e.spec.luau
+++ b/examples/plugin/e2e.spec.luau
@@ -1,14 +1,17 @@
 local frktest = require("@pkg/frktest")
 local fs = require("@lune/fs")
 local process = require("@lune/process")
+local serde = require("@lune/serde")
 
 local getAssetDetailsAsync = require("@root/requests/getAssetDetailsAsync")
 local getOrCreateAssetLockfile = require("@root/manifest/getOrCreateAssetLockfile")
+local readManifest = require("@root/manifest/readManifest")
 
 local test = frktest.test
 local check = frktest.assert.check
 
 local ROOT_PATH = "examples/plugin"
+local MANIFEST_PATH = `{ROOT_PATH}/rbxasset.toml`
 
 local apiKey = process.env.ROBLOX_API_KEY
 assert(apiKey, "End-to-end tests can only be run when the ROBLOX_API_KEY envvar is set to a valid Open Cloud API key")
@@ -38,6 +41,31 @@ test.case("uploads to the Creator Store", function()
 
 	assetDetails = getAssetDetailsAsync(assetId, apiKey)
 
+	check.not_equal(assetDetails.revisionId, prevRevisionId)
+end)
+
+test.case("text fields in rbxasest.toml get mirrored to the asset details", function()
+	local assetDetails = getAssetDetailsAsync(assetId, apiKey)
+	local prevRevisionId = assetDetails.revisionId
+
+	local manifest = readManifest(ROOT_PATH)
+
+	local id = math.random(1, 1e10)
+	manifest.assets.plugin.name = `{manifest.assets.plugin.name}\n({id})`
+	manifest.assets.plugin.description = `{manifest.assets.plugin.description}\n({id})`
+
+	fs.writeFile(MANIFEST_PATH, serde.encode("toml", manifest))
+
+	process.exec("lune", { "run", "deploy.luau", apiKey }, {
+		cwd = ROOT_PATH,
+	})
+
+	process.exec("git", { "restore", MANIFEST_PATH })
+
+	assetDetails = getAssetDetailsAsync(assetId, apiKey)
+
+	check.equal(assetDetails.displayName, manifest.assets.plugin.name)
+	check.equal(assetDetails.description, manifest.assets.plugin.description)
 	check.not_equal(assetDetails.revisionId, prevRevisionId)
 end)
 

--- a/examples/plugin/e2e.spec.luau
+++ b/examples/plugin/e2e.spec.luau
@@ -54,7 +54,7 @@ test.case("text fields in rbxasest.toml get mirrored to the asset details", func
 
 	local manifest = readManifest(ROOT_PATH)
 
-	local id = math.random(1, 1e10)
+	local id = os.time()
 	manifest.assets.plugin.name = `{manifest.assets.plugin.name}\n({id})`
 	manifest.assets.plugin.description = `{manifest.assets.plugin.description}\n({id})`
 

--- a/examples/plugin/e2e.spec.luau
+++ b/examples/plugin/e2e.spec.luau
@@ -1,0 +1,56 @@
+local frktest = require("@pkg/frktest")
+local fs = require("@lune/fs")
+local process = require("@lune/process")
+
+local getAssetDetailsAsync = require("@root/requests/getAssetDetailsAsync")
+local getOrCreateAssetLockfile = require("@root/manifest/getOrCreateAssetLockfile")
+
+local test = frktest.test
+local check = frktest.assert.check
+
+local ROOT_PATH = "examples/plugin"
+
+local apiKey = process.env.ROBLOX_API_KEY
+assert(apiKey, "End-to-end tests can only be run when the ROBLOX_API_KEY envvar is set to a valid Open Cloud API key")
+
+local lockfile = getOrCreateAssetLockfile(ROOT_PATH)
+local assetId = lockfile.assets.plugin.assetId
+
+process.exec("rojo", { "build", "-o", "plugin.rbxm" }, {
+	cwd = ROOT_PATH,
+})
+
+test.case("uploads to the Creator Store", function()
+	local assetDetails = getAssetDetailsAsync(assetId, apiKey)
+
+	local prevRevisionId = assetDetails.revisionId
+
+	local path = `{ROOT_PATH}/src/init.plugin.luau`
+	local content = fs.readFile(path)
+	content ..= `\nprint("New!")`
+	fs.writeFile(path, content)
+
+	process.exec("lune", { "run", "deploy.luau", apiKey }, {
+		cwd = ROOT_PATH,
+	})
+
+	process.exec("git", { "restore", path })
+
+	assetDetails = getAssetDetailsAsync(assetId, apiKey)
+
+	check.not_equal(assetDetails.revisionId, prevRevisionId)
+end)
+
+test.case("does not publish a new version when there are no changes", function()
+	local assetDetails = getAssetDetailsAsync(assetId, apiKey)
+
+	local prevRevisionId = assetDetails.revisionId
+
+	process.exec("lune", { "run", "deploy.luau", apiKey }, {
+		cwd = ROOT_PATH,
+	})
+
+	assetDetails = getAssetDetailsAsync(assetId, apiKey)
+
+	check.equal(assetDetails.revisionId, prevRevisionId)
+end)

--- a/examples/plugin/e2e.spec.luau
+++ b/examples/plugin/e2e.spec.luau
@@ -13,6 +13,12 @@ local check = frktest.assert.check
 local ROOT_PATH = "examples/plugin"
 local MANIFEST_PATH = `{ROOT_PATH}/rbxasset.toml`
 
+local function appendTextForTesting(path: string, text: string)
+	local content = fs.readFile(path)
+	content ..= text
+	fs.writeFile(path, content)
+end
+
 local apiKey = process.env.ROBLOX_API_KEY
 assert(apiKey, "End-to-end tests can only be run when the ROBLOX_API_KEY envvar is set to a valid Open Cloud API key")
 
@@ -29,9 +35,7 @@ test.case("uploads to the Creator Store", function()
 	local prevRevisionId = assetDetails.revisionId
 
 	local path = `{ROOT_PATH}/src/init.plugin.luau`
-	local content = fs.readFile(path)
-	content ..= `\nprint("New!")`
-	fs.writeFile(path, content)
+	appendTextForTesting(path, `\nprint("New!")`)
 
 	process.exec("lune", { "run", "deploy.luau", apiKey }, {
 		cwd = ROOT_PATH,

--- a/examples/plugin/rbxasset.lock
+++ b/examples/plugin/rbxasset.lock
@@ -1,6 +1,6 @@
 [assets.plugin]
-assetId = "129177256438878"
+assetId = "99715727817578"
 
 [images."icon.png"]
-assetId = "140397768102119"
+assetId = "137935794552622"
 hash = "fac185770cf5e824d4c0a9b59e547df42dc10011c5ad139bfc2c7e1507eef631"

--- a/examples/workspace/e2e.spec.luau
+++ b/examples/workspace/e2e.spec.luau
@@ -65,7 +65,7 @@ test.case("text fields in rbxasest.toml get mirrored to the asset details", func
 
 	local manifest = readManifest(ROOT_PATH)
 
-	local id = math.random(1, 1e10)
+	local id = os.time()
 
 	manifest.assets.package.name = `{manifest.assets.package.name}\n({id})`
 	manifest.assets.package.description = `{manifest.assets.package.description}\n({id})`

--- a/examples/workspace/e2e.spec.luau
+++ b/examples/workspace/e2e.spec.luau
@@ -1,0 +1,98 @@
+local frktest = require("@pkg/frktest")
+local fs = require("@lune/fs")
+local process = require("@lune/process")
+local serde = require("@lune/serde")
+
+local getAssetDetailsAsync = require("@root/requests/getAssetDetailsAsync")
+local getOrCreateAssetLockfile = require("@root/manifest/getOrCreateAssetLockfile")
+local readManifest = require("@root/manifest/readManifest")
+
+local test = frktest.test
+local check = frktest.assert.check
+
+local ROOT_PATH = "examples/workspace"
+local MANIFEST_PATH = `{ROOT_PATH}/rbxasset.toml`
+
+local apiKey = process.env.ROBLOX_API_KEY
+assert(apiKey, "End-to-end tests can only be run when the ROBLOX_API_KEY envvar is set to a valid Open Cloud API key")
+
+local lockfile = getOrCreateAssetLockfile(ROOT_PATH)
+local packageAssetId = lockfile.assets.package.assetId
+local pluginAssetId = lockfile.assets.plugin.assetId
+
+process.exec("rojo", { "build", "-o", "plugin.rbxm" }, {
+	cwd = ROOT_PATH,
+})
+
+test.case("uploads each workspace member to the Creator Store", function()
+	local packageAssetDetails = getAssetDetailsAsync(packageAssetId, apiKey)
+	local pluginAssetDetails = getAssetDetailsAsync(pluginAssetId, apiKey)
+
+	local prevPackageRevisionId = packageAssetDetails.revisionId
+	local prevPluginRevisionId = pluginAssetDetails.revisionId
+
+	local filesToChange = {
+		`{ROOT_PATH}/package/src/init.luau`,
+		`{ROOT_PATH}/plugin/src/init.plugin.luau`,
+	}
+
+	for _, path in filesToChange do
+		local content = fs.readFile(path)
+		content ..= `\nprint("New!")`
+		fs.writeFile(path, content)
+	end
+
+	process.exec("lune", { "run", "deploy.luau", apiKey }, {
+		cwd = ROOT_PATH,
+	})
+
+	process.exec("git", { "restore", table.unpack(filesToChange) })
+
+	packageAssetDetails = getAssetDetailsAsync(packageAssetId, apiKey)
+	pluginAssetDetails = getAssetDetailsAsync(pluginAssetId, apiKey)
+
+	check.not_equal(packageAssetDetails.revisionId, prevPackageRevisionId)
+	check.not_equal(pluginAssetDetails.revisionId, prevPluginRevisionId)
+end)
+
+test.case("text fields in rbxasest.toml get mirrored to the asset details", function()
+	local packageAssetDetails = getAssetDetailsAsync(packageAssetId, apiKey)
+	local prevRevisionId = packageAssetDetails.revisionId
+
+	local manifest = readManifest(ROOT_PATH)
+
+	local id = math.random(1, 1e10)
+	manifest.assets.plugin.name = `{manifest.assets.plugin.name}\n({id})`
+	manifest.assets.plugin.description = `{manifest.assets.plugin.description}\n({id})`
+
+	fs.writeFile(MANIFEST_PATH, serde.encode("toml", manifest))
+
+	process.exec("lune", { "run", "deploy.luau", apiKey }, {
+		cwd = ROOT_PATH,
+	})
+
+	process.exec("git", { "restore", MANIFEST_PATH })
+
+	packageAssetDetails = getAssetDetailsAsync(packageAssetId, apiKey)
+
+	check.equal(packageAssetDetails.displayName, manifest.assets.plugin.name)
+	check.equal(packageAssetDetails.description, manifest.assets.plugin.description)
+	check.not_equal(packageAssetDetails.revisionId, prevRevisionId)
+end)
+
+test.case("only publishes a new version for changed workspace members", function()
+	local packageAssetDetails = getAssetDetailsAsync(packageAssetId, apiKey)
+
+	local prevRevisionId = packageAssetDetails.revisionId
+
+	-- TODO: Make a change to one workspace member, verify that one got a new
+	-- revision but that the other did not
+
+	process.exec("lune", { "run", "deploy.luau", apiKey }, {
+		cwd = ROOT_PATH,
+	})
+
+	packageAssetDetails = getAssetDetailsAsync(packageAssetId, apiKey)
+
+	check.equal(packageAssetDetails.revisionId, prevRevisionId)
+end)

--- a/examples/workspace/e2e.spec.luau
+++ b/examples/workspace/e2e.spec.luau
@@ -20,6 +20,12 @@ local lockfile = getOrCreateAssetLockfile(ROOT_PATH)
 local packageAssetId = lockfile.assets.package.assetId
 local pluginAssetId = lockfile.assets.plugin.assetId
 
+local function appendTextForTesting(path: string, text: string)
+	local content = fs.readFile(path)
+	content ..= text
+	fs.writeFile(path, content)
+end
+
 process.exec("rojo", { "build", "-o", "plugin.rbxm" }, {
 	cwd = ROOT_PATH,
 })
@@ -37,9 +43,7 @@ test.case("uploads each workspace member to the Creator Store", function()
 	}
 
 	for _, path in filesToChange do
-		local content = fs.readFile(path)
-		content ..= `\nprint("New!")`
-		fs.writeFile(path, content)
+		appendTextForTesting(path, `\nprint("New!")`)
 	end
 
 	process.exec("lune", { "run", "deploy.luau", apiKey }, {
@@ -57,11 +61,15 @@ end)
 
 test.case("text fields in rbxasest.toml get mirrored to the asset details", function()
 	local packageAssetDetails = getAssetDetailsAsync(packageAssetId, apiKey)
-	local prevRevisionId = packageAssetDetails.revisionId
+	local pluginAssetDetails = getAssetDetailsAsync(pluginAssetId, apiKey)
 
 	local manifest = readManifest(ROOT_PATH)
 
 	local id = math.random(1, 1e10)
+
+	manifest.assets.package.name = `{manifest.assets.package.name}\n({id})`
+	manifest.assets.package.description = `{manifest.assets.package.description}\n({id})`
+
 	manifest.assets.plugin.name = `{manifest.assets.plugin.name}\n({id})`
 	manifest.assets.plugin.description = `{manifest.assets.plugin.description}\n({id})`
 
@@ -74,25 +82,36 @@ test.case("text fields in rbxasest.toml get mirrored to the asset details", func
 	process.exec("git", { "restore", MANIFEST_PATH })
 
 	packageAssetDetails = getAssetDetailsAsync(packageAssetId, apiKey)
+	pluginAssetDetails = getAssetDetailsAsync(pluginAssetId, apiKey)
 
-	check.equal(packageAssetDetails.displayName, manifest.assets.plugin.name)
-	check.equal(packageAssetDetails.description, manifest.assets.plugin.description)
-	check.not_equal(packageAssetDetails.revisionId, prevRevisionId)
+	check.equal(packageAssetDetails.displayName, manifest.assets.package.name)
+	check.equal(packageAssetDetails.description, manifest.assets.package.description)
+
+	check.equal(pluginAssetDetails.displayName, manifest.assets.plugin.name)
+	check.equal(pluginAssetDetails.description, manifest.assets.plugin.description)
 end)
 
 test.case("only publishes a new version for changed workspace members", function()
 	local packageAssetDetails = getAssetDetailsAsync(packageAssetId, apiKey)
+	local pluginAssetDetails = getAssetDetailsAsync(pluginAssetId, apiKey)
 
-	local prevRevisionId = packageAssetDetails.revisionId
+	local prevPackageRevisionId = packageAssetDetails.revisionId
+	local prevPluginRevisionId = pluginAssetDetails.revisionId
 
-	-- TODO: Make a change to one workspace member, verify that one got a new
-	-- revision but that the other did not
+	-- We make a change to a single workspace member so we can verify that only
+	-- that member was given a new revision after publishing
+	local path = `{ROOT_PATH}/package/src/init.luau`
+	appendTextForTesting(path, `\nprint("New!")`)
 
 	process.exec("lune", { "run", "deploy.luau", apiKey }, {
 		cwd = ROOT_PATH,
 	})
 
-	packageAssetDetails = getAssetDetailsAsync(packageAssetId, apiKey)
+	process.exec("git", { "restore", path })
 
-	check.equal(packageAssetDetails.revisionId, prevRevisionId)
+	packageAssetDetails = getAssetDetailsAsync(packageAssetId, apiKey)
+	pluginAssetDetails = getAssetDetailsAsync(pluginAssetId, apiKey)
+
+	check.not_equal(packageAssetDetails.revisionId, prevPackageRevisionId)
+	check.equal(pluginAssetDetails.revisionId, prevPluginRevisionId)
 end)

--- a/examples/workspace/package/src/init.luau
+++ b/examples/workspace/package/src/init.luau
@@ -1,5 +1,1 @@
-return {
-	hello = function()
-		print("Hello, World!")
-	end,
-}
+print("This is a Package!")

--- a/examples/workspace/plugin/src/init.luau
+++ b/examples/workspace/plugin/src/init.luau
@@ -1,5 +1,0 @@
-return {
-	hello = function()
-		print("Hello, World!")
-	end,
-}

--- a/examples/workspace/plugin/src/init.plugin.luau
+++ b/examples/workspace/plugin/src/init.plugin.luau
@@ -1,0 +1,1 @@
+print("This is a plugin!")

--- a/examples/workspace/rbxasset.lock
+++ b/examples/workspace/rbxasset.lock
@@ -1,13 +1,13 @@
 [assets.package]
-assetId = "122373732145451"
+assetId = "89520538661957"
 
 [assets.plugin]
-assetId = "90616066886156"
+assetId = "71396034410547"
 
 [images."package/icon.png"]
-assetId = "97869612199401"
+assetId = "77683406540578"
 hash = "fac185770cf5e824d4c0a9b59e547df42dc10011c5ad139bfc2c7e1507eef631"
 
 [images."plugin/icon.png"]
-assetId = "91168078927982"
+assetId = "131332912508844"
 hash = "fac185770cf5e824d4c0a9b59e547df42dc10011c5ad139bfc2c7e1507eef631"

--- a/src/manifest/getOrCreateAssetLockfile.spec.luau
+++ b/src/manifest/getOrCreateAssetLockfile.spec.luau
@@ -6,7 +6,7 @@ local getOrCreateAssetLockfile = require("./getOrCreateAssetLockfile")
 
 test.case("reads an asset lockfile from disk", function()
 	local lockfile = getOrCreateAssetLockfile("examples/package")
-	check.equal(lockfile.assets["package"].assetId, "120786139379662")
+	check.equal(lockfile.assets["package"].assetId, "85269576874155")
 end)
 
 test.case("creates a blank asset lockfile when not found on disk", function()

--- a/src/requests/fetch.luau
+++ b/src/requests/fetch.luau
@@ -33,6 +33,8 @@ local function fetch(url: string, options: FetchOptions)
 			for _, err in body.errors do
 				table.insert(problems, err.message)
 			end
+		elseif body.message then
+			table.insert(problems, body.message)
 		end
 
 		error(


### PR DESCRIPTION
This PR adds end-to-end tests for all of the example projects. My goal with this PR is to pin the prod behavior of interacting with Open Cloud. The tests make deployments to the Creator Store and then verify that those changes were successfully deployed

This will also help with #6 to ensure that such a big change to the upload flow won't cause any major regressions

A couple of the e2e tests fail right now but I'd like to move forward regardless and will just leave the step as non-blocking. The bulk of the checks should provide value for the other PRs I have in the pipeline